### PR TITLE
Add Feature: Delete Transactions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,10 @@ FROM bxbrenden/docker-ide:0.1.0
 
 LABEL "maintainer"="brendenahyde@gmail.com"
 
-USER brenden
+USER root
 
 # Install app and dependencies
-RUN sudo mkdir /app
-RUN sudo chown -R brenden /app
+RUN mkdir /app
 WORKDIR /app
 ADD requirements.txt requirements.txt
 RUN /home/brenden/.pyenv/shims/pip3 install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,20 @@
-FROM bxbrenden/docker-ide:latest
+FROM bxbrenden/docker-ide:0.1.0
 
 LABEL "maintainer"="brendenahyde@gmail.com"
 
-USER root
+USER brenden
 
 # Install app and dependencies
-RUN mkdir /GnuCash-Helper
-WORKDIR /GnuCash-Helper
+RUN sudo mkdir /app
+RUN sudo chown -R brenden /app
+WORKDIR /app
 ADD requirements.txt requirements.txt
-ADD gnucash_helper.py gnucash_helper.py
-ADD app.py app.py
-RUN pip3 install -r requirements.txt
+RUN /home/brenden/.pyenv/shims/pip3 install -r requirements.txt
 COPY templates/ templates/
 COPY static/ static/
-
-# Make the dir where your GnuCash file will live inside the container
-ENV GNUCASH_DIR=/gnucash
-RUN mkdir $GNUCASH_DIR
-
-# This is the name of your GnuCash file
-ENV GNUCASH_FILE=budget.gnucash
-
-# Number of transactions that will be visible in txn history
-ENV NUM_TRANSACTIONS="200"
+ADD gnucash_helper.py gnucash_helper.py
+ADD app.py app.py
 
 EXPOSE 8000
 
-CMD ["gunicorn", "-b", "0.0.0.0:8000", "--worker-tmp-dir", "/dev/shm", "app:app"]
+CMD ["/home/brenden/.pyenv/shims/gunicorn", "-b", "0.0.0.0:8000", "--worker-tmp-dir", "/dev/shm", "app:app"]

--- a/README.md
+++ b/README.md
@@ -23,13 +23,15 @@ docker pull bxbrenden/gnucash-helper:latest
 
 ## Running the Docker Container
 This example run assumes that your environment meets these criteria:
+- You have a Docker volume created with `docker volume create gnucash`
 - You have `syncthing` installed and running
 - `syncthing` is using a directory called `Sync` in your home directory
-- The `Sync` directory in your home directory contains a file called `your_gnucash_file.gnucash`
+- The `Sync` directory in your home directory contains a file called `demo-budget.gnucash`
+- The `demo-budget.gnucash` file in `Sync` is symlinked into the `gnucash` Docker volume
 
 Example run:
 ```bash
-docker run -e "GNUCASH_FILE=your_gnucash_file.gnucash" --restart unless-stopped -d -p 8000:8000 -v "$(pwd)/Sync":/gnucash bxbrenden/gnucash-helper:latest
+docker run --restart unless-stopped -d -p 8000:8000 -v gnucash:/gnucash -e GNUCASH_FILE=demo-budget.gnucash -e GNUCASH_DIR=/gnucash -e NUM_TRANSACTIONS=1000  bxbrenden/gnucash-helper:0.1.0
 ```
 
 ## Configuration

--- a/app.py
+++ b/app.py
@@ -5,7 +5,9 @@ from gnucash_helper import list_accounts,\
                            get_gnucash_dir,\
                            last_n_transactions,\
                            get_env_var,\
-                           logger
+                           logger,\
+                           summarize_transaction,\
+                           delete_transaction
 
 from decimal import ROUND_HALF_UP
 import os
@@ -57,6 +59,31 @@ class TransactionForm(FlaskForm):
         return txn_form
 
 
+class DeleteTransactionForm(FlaskForm):
+    del_transactions = SelectField('Select a Transaction to Delete',
+                                   validators=[DataRequired()],
+                                   validate_choice=True)
+    submit = SubmitField('Submit')
+
+    @classmethod
+    def new(cls):
+        """Instantiate a new TransactionForm."""
+        global path_to_book
+        global logger
+        logger.info('Attempting to read GnuCash book to create DeleteTransactionForm.')
+        transactions = last_n_transactions(path_to_book, 0)
+
+        # List of summarized txns to display in dropdown box
+        summaries = []
+        for t in transactions:
+            summaries.append(summarize_transaction(t))
+
+        txn_form = cls()
+        txn_form.del_transactions.choices = summaries
+
+        return txn_form
+
+
 app = Flask(__name__)
 app.config['SECRET_KEY'] = env.get('FLASK_SECRET_KEY',
                                    'Mjpe[){i>"r3}]Fm+-{7#,m}qFtf!w)T')
@@ -74,11 +101,11 @@ def index():
 @app.route('/entry', methods=['GET', 'POST'])
 def entry():
     global logger
-    logger.info('Creating new form inside of the entry route')
+    logger.info('Creating new form inside of the /entry route')
     form = TransactionForm.new()
     if form.validate_on_submit():
         # Add the transaction to the GnuCash book
-        logger.info('Attempting to open book in entry route')
+        logger.info('Attempting to open book in /entry route')
         gnucash_book = open_book(path_to_book)
         descrip = form.description.data
         amount = form.amount.data
@@ -96,6 +123,32 @@ def entry():
 
         return redirect(url_for('entry'))
     return render_template('entry.html', form=form)
+
+
+@app.route('/delete', methods=['GET', 'POST'])
+def delete():
+    global logger
+    logger.info('Creating new form inside of the /delete route')
+    form = DeleteTransactionForm.new()
+    if form.validate_on_submit():
+        # Delete the transaction from the GnuCash book
+        logger.info('Attempting to open book in /delete route')
+        gnucash_book = open_book(path_to_book)
+        txn_to_delete = form.del_transactions.data
+        txn_deleted = delete_transaction(gnucash_book, txn_to_delete)
+        gnucash_book.close()
+
+        if txn_deleted:
+            message = 'Transaction deleted from GnuCash file:\n'
+            message += txn_to_delete
+            flash(message, 'success')
+        else:
+            message = 'Transaction was NOT deleted from GnuCash file:\n'
+            message += txn_to_delete
+            flash(message, 'danger')
+
+        return redirect(url_for('entry'))
+    return render_template('delete_txn.html', form=form)
 
 
 @app.route('/transactions')

--- a/app.py
+++ b/app.py
@@ -71,7 +71,8 @@ class DeleteTransactionForm(FlaskForm):
         global path_to_book
         global logger
         logger.info('Attempting to read GnuCash book to create DeleteTransactionForm.')
-        transactions = last_n_transactions(path_to_book, 0)
+        book = open_book(path_to_book)
+        transactions = last_n_transactions(book, 0)
 
         # List of summarized txns to display in dropdown box
         summaries = []

--- a/deletion_notes.md
+++ b/deletion_notes.md
@@ -1,0 +1,19 @@
+# Transactions
+
+## Summary
+As a user, I want to be able to delete transactions from the web app.
+
+## Acceptance Criteria
+- User is able to find a specific txn from a list
+- User can choose to delete it and submit a form
+- The transaction is then removed from the books
+
+## Required Changes / Additions
+- [x] New page for deletions (easier than changing the existing page)
+- [] One or more of these:
+  - [x] a drop-down for selecting transactions
+  - a search bar for finding transactions
+  - a list of txns, basically identical to `/transactions` but with check boxes for deletion
+- [x] A new / changed Jinja2 template
+- [x] Function in `gnucash_helper.py` for transaction deletion
+- [x] new route in `app.py` for deletions, possibly `/delete`

--- a/demo-budget.gnucash
+++ b/demo-budget.gnucash
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e5b2539f4519a5b96bcdacb2d59ada360c958cc130ce07df2e9299d6b85e5f8e
+oid sha256:8c393cc0410e995b90d3ceec3f252ab6aece1d4ca80c93ef0cecfe9c68db9c42
 size 225280

--- a/gnucash_helper.py
+++ b/gnucash_helper.py
@@ -209,6 +209,8 @@ def add_transaction(book, description, amount, debit_acct, credit_acct):
                                           Split(value=amount, account=credit),
                                           Split(value=-amount, account=debit)
                                       ])
+            logger.debug('Transaction successfully created.')
+            logger.debug('Attempting to save transaction')
             book.save()
             logger.info('Successfully saved transaction')
             return True

--- a/gnucash_helper.py
+++ b/gnucash_helper.py
@@ -13,7 +13,7 @@ def configure_logging():
     logger.setLevel(logging.DEBUG)
     ch = logging.StreamHandler()
     ch.setLevel(logging.DEBUG)
-    fh = logging.FileHandler('/gnucash-helper.log', encoding='utf-8')
+    fh = logging.FileHandler('/app/gnucash-helper.log', encoding='utf-8')
     fh.setLevel(logging.DEBUG)
     formatter = logging.Formatter('%(asctime)s  %(name)s  %(levelname)s:%(message)s')
     ch.setFormatter(formatter)
@@ -255,12 +255,13 @@ def summarize_transaction(txn):
 
     # Create summary components
     desc_summ = txn['description'][:20]
+    amount = txn['amount']
     date = txn['date']
     src_summ = txn['source'].split(':')[-1]
     dest_summ = txn['dest'].split(':')[-1]
     guid = txn['guid']
 
-    summary = f'Txn: {desc_summ},Date: {date},Source: {src_summ},Dest: {dest_summ},GUID: {guid}'
+    summary = f'Txn: {desc_summ},Amount: {amount},Date: {date},Source: {src_summ},Dest: {dest_summ},GUID: {guid}'
 
     return summary
 

--- a/gnucash_helper.py
+++ b/gnucash_helper.py
@@ -254,7 +254,7 @@ def summarize_transaction(txn):
             raise SystemExit
 
     # Create summary components
-    desc_summ = txn['description'][:10]
+    desc_summ = txn['description'][:20]
     date = txn['date']
     src_summ = txn['source'].split(':')[-1]
     dest_summ = txn['dest'].split(':')[-1]

--- a/templates/base.html
+++ b/templates/base.html
@@ -22,6 +22,7 @@
 	        <li><a href="/entry">Make Entry</a></li>
 		<li><a href="/transactions">Transaction History</a></li>
 		<li><a href="/balances">Balances</a></li>
+		<li><a href="/delete">Delete</a></li>
 	      </ul>
       </div>
     </div>

--- a/templates/delete_txn.html
+++ b/templates/delete_txn.html
@@ -1,43 +1,11 @@
 {% extends "base.html" %}
 
-{% block title %}Delete Transaction{% endblock %}
-{% block styles %}
-{{ super() }}
-<link rel="stylesheet" href="{{ url_for('static', filename='transactions.css')  }}">
-{% endblock %}
+{% import "bootstrap/wtf.html" as wtf %}
+
+{% block title %} CheckYour Finance  {% endblock %}
 {% block page_content %}
 <div class="page-header">
-  <h1>Delete Transaction</h1>
-  <h3>List of transactions</h3>
+  <h1>Delete a Transaction</h1>
 </div>
-<div>
-  <table class="table">
-    <thead>
-      <th>Delete?</th>
-      <th>Source Account</th>
-      <th>Destination Account</th>
-      <th>Date</th>
-      <th>Description</th>
-      <th>Amount</th>
-      <th>GUID</th>
-    </thead>
-    <tbody>
-      {% for trans in transactions %}
-      {% if loop.index0 % 2 == 0 %}
-      <tr class="evenrow">
-      {% else %}
-      <tr class="oddrow">
-      {% endif %}
-        <td><input type=checkbox id=delete_{{ trans['guid'] }}></td>
-	<td>{{ trans['source'] }}</td>
-	<td>{{ trans['dest'] }}</td>
-	<td>{{ trans['date'] }}</td>
-	<td>{{ trans['description'] }}</td>
-	<td>{{ trans['amount'] }}</td>
-	<td>{{ trans['guid'] }}</td>
-      </tr>
-      {% endfor %}
-    </tbody>
-  </table>
-</div>
+{{ wtf.quick_form(form) }}
 {% endblock %}

--- a/templates/delete_txn.html
+++ b/templates/delete_txn.html
@@ -1,0 +1,43 @@
+{% extends "base.html" %}
+
+{% block title %}Delete Transaction{% endblock %}
+{% block styles %}
+{{ super() }}
+<link rel="stylesheet" href="{{ url_for('static', filename='transactions.css')  }}">
+{% endblock %}
+{% block page_content %}
+<div class="page-header">
+  <h1>Delete Transaction</h1>
+  <h3>List of transactions</h3>
+</div>
+<div>
+  <table class="table">
+    <thead>
+      <th>Delete?</th>
+      <th>Source Account</th>
+      <th>Destination Account</th>
+      <th>Date</th>
+      <th>Description</th>
+      <th>Amount</th>
+      <th>GUID</th>
+    </thead>
+    <tbody>
+      {% for trans in transactions %}
+      {% if loop.index0 % 2 == 0 %}
+      <tr class="evenrow">
+      {% else %}
+      <tr class="oddrow">
+      {% endif %}
+        <td><input type=checkbox id=delete_{{ trans['guid'] }}></td>
+	<td>{{ trans['source'] }}</td>
+	<td>{{ trans['dest'] }}</td>
+	<td>{{ trans['date'] }}</td>
+	<td>{{ trans['description'] }}</td>
+	<td>{{ trans['amount'] }}</td>
+	<td>{{ trans['guid'] }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}


### PR DESCRIPTION
Up till now, GnuCash-Helper was unable to delete transactions from the books; you simply had to open the `.gnucash` file in GnuCash itself and delete the transaction there. This PR adds the feature of deletion.