### PR TITLE
add horizontal divider and rearrange divs

### DIFF
--- a/gnucash_helper.py
+++ b/gnucash_helper.py
@@ -7,26 +7,6 @@ import piecash
 from piecash import Transaction, Split, GnucashException
 
 
-def configure_logging():
-    """Set up logging for the module."""
-    logger = logging.getLogger(__name__)
-    logger.setLevel(logging.DEBUG)
-    formatter = logging.Formatter('%(asctime)s  %(name)s  %(levelname)s:%(message)s')
-    ch = logging.StreamHandler()
-    ch.setLevel(logging.DEBUG)
-    ch.setFormatter(formatter)
-    fh = logging.FileHandler('/app/gnucash-helper.log', encoding='utf-8')
-    fh.setLevel(logging.DEBUG)
-    fh.setFormatter(formatter)
-    logger.addHandler(fh)
-    logger.addHandler(ch)
-
-    return logger
-
-
-logger = configure_logging()
-
-
 def get_env_var(name):
     """Get the environment variable `name` from environment variable.
 
@@ -38,6 +18,27 @@ def get_env_var(name):
         logger.critical(f'Could not get env. var. "{ke}". Make sure it is set')
     else:
         return env_var
+
+
+def configure_logging():
+    """Set up logging for the module."""
+    logger = logging.getLogger(__name__)
+    logger.setLevel(logging.DEBUG)
+    formatter = logging.Formatter('%(asctime)s  %(name)s  %(levelname)s:%(message)s')
+    ch = logging.StreamHandler()
+    ch.setLevel(logging.DEBUG)
+    ch.setFormatter(formatter)
+    if gnucash_dir := get_env_var('GNUCASH_DIR'):
+        fh = logging.FileHandler(f'{gnucash_dir}/gnucash-helper.log', encoding='utf-8')
+        fh.setLevel(logging.DEBUG)
+        fh.setFormatter(formatter)
+        logger.addHandler(fh)
+    logger.addHandler(ch)
+
+    return logger
+
+
+logger = configure_logging()
 
 
 def get_book_name_from_env():

--- a/templates/accounts.html
+++ b/templates/accounts.html
@@ -6,9 +6,12 @@
 {% block page_content %}
 <div class="page-header">
   <h1>Manage Accounts</h1>
+</div>
+<div>
   <h2>Add an Account</h2>
 </div>
 {{ wtf.quick_form(add_form) }}
+<hr/>
 <div>
   <h2>Delete an Account</h2>
 </div>


### PR DESCRIPTION
This PR has two components to it:

1. Rearrange `gnucash_helper.py` in order to fix logging for local testing. The `FileHandler` object was causing problems for testing locally because it expected `/app` to exist and be writable. Now everything gets written to `$GNUCASH_DIR`.
2. Add some small horizontal bars in key places on the `Manage Accounts` page. This is purely a visual set of separators to make things clearer.