### PR TITLE
Add Date picker

### DIFF
--- a/app.py
+++ b/app.py
@@ -26,7 +26,7 @@ from wtforms import DecimalField,\
                     SubmitField,\
                     TextAreaField,\
                     StringField
-from wtforms.fields import DateField
+from wtforms.fields import DateTimeField
 from wtforms.validators import DataRequired
 
 book_name = get_book_name_from_env()
@@ -54,7 +54,8 @@ class TransactionForm(FlaskForm):
                           rounding=ROUND_HALF_UP,
                           render_kw={'placeholder': 'Ex: 4.20'})
     description = TextAreaField('Description', validators=[DataRequired()])
-    date = DateField('DatePicker', format='%Y-%m-%d')
+    date = DateTimeField('Date',
+                         validators=[DataRequired()])
     submit = SubmitField('Submit')
 
     @classmethod

--- a/app.py
+++ b/app.py
@@ -26,7 +26,7 @@ from wtforms import DecimalField,\
                     SubmitField,\
                     TextAreaField,\
                     StringField
-from wtforms.fields import DateTimeField
+from wtforms.fields import DateField
 from wtforms.validators import DataRequired
 
 book_name = get_book_name_from_env()
@@ -54,8 +54,8 @@ class TransactionForm(FlaskForm):
                           rounding=ROUND_HALF_UP,
                           render_kw={'placeholder': 'Ex: 4.20'})
     description = TextAreaField('Description', validators=[DataRequired()])
-    date = DateTimeField('Date',
-                         validators=[DataRequired()])
+    date = DateField('Date',
+                     validators=[DataRequired()])
     submit = SubmitField('Submit')
 
     @classmethod

--- a/app.py
+++ b/app.py
@@ -26,7 +26,7 @@ from wtforms import DecimalField,\
                     SubmitField,\
                     TextAreaField,\
                     StringField
-
+from wtforms.fields.html5 import DateField
 from wtforms.validators import DataRequired
 
 book_name = get_book_name_from_env()
@@ -54,6 +54,7 @@ class TransactionForm(FlaskForm):
                           rounding=ROUND_HALF_UP,
                           render_kw={'placeholder': 'Ex: 4.20'})
     description = TextAreaField('Description', validators=[DataRequired()])
+    date = DateField('DatePicker', format='%Y-%m-%d')
     submit = SubmitField('Submit')
 
     @classmethod

--- a/app.py
+++ b/app.py
@@ -26,7 +26,7 @@ from wtforms import DecimalField,\
                     SubmitField,\
                     TextAreaField,\
                     StringField
-from wtforms.fields.html5 import DateField
+from wtforms.fields import DateField
 from wtforms.validators import DataRequired
 
 book_name = get_book_name_from_env()

--- a/app.py
+++ b/app.py
@@ -13,7 +13,7 @@ from gnucash_helper import list_accounts,\
                            get_scaleway_s3_client,\
                            download_gnucash_file_from_scaleway_s3,\
                            upload_gnucash_file_to_s3_and_delete_local
-
+from datetime import datetime
 from decimal import ROUND_HALF_UP
 import os
 from os import environ as env
@@ -190,7 +190,11 @@ def entry():
         amount = form.amount.data
         credit = form.credit.data
         debit = form.debit.data
-        added_txn = add_transaction(gnucash_book, descrip, amount, debit, credit)
+        date = form.date.data
+        time = datetime.utcnow().time()
+        enter_datetime = datetime.combine(date, time)
+
+        added_txn = add_transaction(gnucash_book, descrip, amount, debit, credit, enter_datetime)
         gnucash_book.close()
 
         # Upload the GnuCash book to Scaleway S3 and delete local copy

--- a/gnucash_helper.py
+++ b/gnucash_helper.py
@@ -224,12 +224,13 @@ def last_n_transactions(book, n=50):
     return last_n
 
 
-def add_transaction(book, description, amount, debit_acct, credit_acct):
+def add_transaction(book, description, amount, debit_acct, credit_acct, enter_datetime):
     """Add a transaction to an existing book.
 
     `amount` should be a float out to 2 decimal places for the value of the transaction.
     `debit_acct` and `credit_acct` should be the names of the accounts as given by the .fullname
     method from a GnuCash Account, e.g. book.accounts.get(fullname="Expenses:Food").
+    `enter_datetime` should be of type datetime.datetime.
     """
     try:
         credit = get_account(credit_acct, book)
@@ -239,6 +240,7 @@ def add_transaction(book, description, amount, debit_acct, credit_acct):
             logger.info('Creating a new transaction in the GnuCash book.')
             transaction = Transaction(currency=usd,
                                       description=description,
+                                      enter_date=enter_datetime,
                                       splits=[
                                           Split(value=amount, account=credit),
                                           Split(value=-amount, account=debit)

--- a/gnucash_helper.py
+++ b/gnucash_helper.py
@@ -176,6 +176,9 @@ def last_n_transactions(book, n=50):
         transactions = [x for x in reversed(book.transactions[-n:])]
     elif n == 0:
         transactions = [x for x in reversed(book.transactions)]
+
+    # Sort transactions by date
+    transactions.sort(key=lambda x: x.enter_date)
     logger.debug(f'`n` was set to {n} for getting last transactions')
     logger.debug(f'There are {len(transactions)} transactions in the list')
 

--- a/gnucash_helper.py
+++ b/gnucash_helper.py
@@ -178,7 +178,7 @@ def last_n_transactions(book, n=50):
         transactions = [x for x in reversed(book.transactions)]
 
     # Sort transactions by date
-    transactions.sort(key=lambda x: x.enter_date)
+    transactions.sort(key=lambda x: x.enter_date, reverse=True)
     logger.debug(f'`n` was set to {n} for getting last transactions')
     logger.debug(f'There are {len(transactions)} transactions in the list')
 


### PR DESCRIPTION
This PR resolves issue #21 by adding a date picker that allows the user to put in a date for an entered transaction. This lets a person enter a transaction from, e.g., a month ago and have it show up in the right order in the `/transactions` page.