### PR TITLE
Set logging level by environment variable or default to INFO

### DIFF
--- a/gnucash_helper.py
+++ b/gnucash_helper.py
@@ -28,7 +28,8 @@ def get_env_var(name):
 def configure_logging():
     """Set up logging for the module."""
     logger = logging.getLogger(__name__)
-    logger.setLevel(logging.DEBUG)
+    log_level = os.environ.get('GNUCASH_LOG_LEVEL') or logging.INFO
+    logger.setLevel(log_level)
     formatter = logging.Formatter('%(asctime)s  %(name)s  %(levelname)s:%(message)s')
     ch = logging.StreamHandler()
     ch.setLevel(logging.DEBUG)


### PR DESCRIPTION
The default logging level was previously hard-coded into the app as `DEBUG`, which is noisy. I only want debugging when I'm troubleshooting, so I made it a configurable option using the environment variable `GNUCASH_LOG_LEVEL`. If that variable isn't set, it defaults to `logging.INFO`.