### PR TITLE
Add schema validation for easy-buttons.yml, fail silently

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ ipython = "*"
 ipython-genutils = "*"
 piecash = "==1.2.0"
 PyYAML = "==6.0"
+voluptuous = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d8a670fa87ac96dc165ba0c9b5da874134f0b2e180ae09e52ce296e7e4a0ce44"
+            "sha256": "f6ac37de2cf25339e5a8f0440f556e2093d238c9e49446ffee09bc056cb951d1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -400,6 +400,14 @@
                 "sha256:2c737903b2b6864ebc6167eef7cf3b997126f1aa94bdf590f90f1436d23e480a"
             ],
             "version": "==0.1.3"
+        },
+        "voluptuous": {
+            "hashes": [
+                "sha256:4b838b185f5951f2d6e8752b68fcf18bd7a9c26ded8f143f92d6d28f3921a3e6",
+                "sha256:e8d31c20601d6773cb14d4c0f42aee29c6821bbd1018039aac7ac5605b489723"
+            ],
+            "index": "pypi",
+            "version": "==0.13.1"
         },
         "wcwidth": {
             "hashes": [


### PR DESCRIPTION
This PR enables GnuCash-Helper to validate the schema of `easy-buttons.yml`. If a single validation error occurs, it just fails silently and disables the Easy Buttons feature, still enabling users to enter transactions, etc.

The schema assumes that each entry in `easy-buttons.yml` has a key that is a string of length >= 1, and all its values are required: `source`, `dest`, `descrip`, `emoji`. All of them are strings, and all must be of length >=1. In the case of `emoji`, it has to be _exactly_ a length of 1.