### PR TITLE
Filtered Transaction View + Hyperlinks

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -20,10 +20,10 @@ path_to_book = gnucash_dir + '/' + book_name
 
 
 class TransactionForm(FlaskForm):
-    debit = SelectField('From Account (Debit)',
+    debit = SelectField('From Account',
                         validators=[DataRequired()],
                         validate_choice=True)
-    credit = SelectField('To Account (Credit)',
+    credit = SelectField('To Account',
                          validators=[DataRequired()],
                          validate_choice=True)
     amount = DecimalField('Amount ($)',
@@ -122,10 +122,10 @@ class AddAccountForm(FlaskForm):
 class AddEasyButton(FlaskForm):
     name = StringField('Name',
                        validators=[DataRequired()])
-    debit = SelectField('From Account (Debit)',
+    debit = SelectField('From Account',
                         validators=[DataRequired()],
                         validate_choice=True)
-    credit = SelectField('To Account (Credit)',
+    credit = SelectField('To Account',
                          validators=[DataRequired()],
                          validate_choice=True)
     descrip = TextAreaField('Description',

--- a/app/static/balances.css
+++ b/app/static/balances.css
@@ -18,3 +18,13 @@ td.gcbal {
 body, html {
   background-repeat: no-repeat;
 }
+
+a.acct-link {
+  text-decoration: none;
+  color: #dcdcdc;
+}
+
+a.acct-link:hover {
+  color: #f57d4a;
+  text-decoration: underline;
+}

--- a/app/static/transactions.css
+++ b/app/static/transactions.css
@@ -8,3 +8,13 @@ h1, h2, h3 {
   text-align: center;
   margin-top: 10px;
 }
+
+a.acct-link {
+  text-decoration: none;
+  color: #dcdcdc;
+}
+
+a.acct-link:hover {
+  text-decoration: underline;
+  color: #f57d4a;
+}

--- a/app/templates/balances.html
+++ b/app/templates/balances.html
@@ -22,7 +22,9 @@
       {% else %}
       <tr class="oddrow">
       {% endif %}
-        <td class="gcname">{{ acct['fullname'] }}</td>
+      <td class="gcname">
+        <a class="acct-link" href="{{ url_for('filtered_transactions', account_name=acct['fullname']) }}">{{ acct['fullname']|replace(':', ' ➔ ') }}</a>
+      </td>
 	<td class="gcbal">{{ acct['balance'] }}</td>
       </tr>
       {% endfor %}

--- a/app/templates/filtered_transactions.html
+++ b/app/templates/filtered_transactions.html
@@ -26,8 +26,12 @@
       {% else %}
       <tr class="oddrow">
       {% endif %}
-	<td>{{ trans['source'] }}</td>
-	<td>{{ trans['dest'] }}</td>
+	<td>
+    <a class="acct-link" href="{{ url_for('filtered_transactions', account_name=trans['source']) }}">{{ trans['source'] }}</a>
+  </td>
+	<td>
+    <a class="acct-link" href="{{ url_for('filtered_transactions', account_name=trans['dest']) }}">{{ trans['dest'] }}</a>
+  </td>
 	<td>{{ trans['date'] }}</td>
 	<td>{{ trans['description'] }}</td>
 	<td>{{ trans['amount'] }}</td>

--- a/app/templates/filtered_transactions.html
+++ b/app/templates/filtered_transactions.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+
+{% block title %}{{ account_name }}{% endblock %}
+{% block styles %}
+{{ super() }}
+<link rel="stylesheet" href="{{ url_for('static', filename='transactions.css')  }}">
+{% endblock %}
+{% block page_content %}
+<div class="page-header">
+  <h1>Filtered Transaction History</h1>
+  <h3>{{ account_name }}</h3>
+</div>
+<div>
+  <table class="table">
+    <thead>
+      <th>Source Account</th>
+      <th>Destination Account</th>
+      <th>Date</th>
+      <th>Description</th>
+      <th>Amount</th>
+    </thead>
+    <tbody>
+      {% for trans in transactions %}
+      {% if loop.index0 % 2 == 0 %}
+      <tr class="evenrow">
+      {% else %}
+      <tr class="oddrow">
+      {% endif %}
+	<td>{{ trans['source'] }}</td>
+	<td>{{ trans['dest'] }}</td>
+	<td>{{ trans['date'] }}</td>
+	<td>{{ trans['description'] }}</td>
+	<td>{{ trans['amount'] }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}

--- a/app/templates/transactions.html
+++ b/app/templates/transactions.html
@@ -26,8 +26,12 @@
       {% else %}
       <tr class="oddrow">
       {% endif %}
-	<td>{{ trans['source'] }}</td>
-	<td>{{ trans['dest'] }}</td>
+      <td>
+        <a class="acct-link" href="{{ url_for('filtered_transactions', account_name=trans['source']) }}">{{ trans['source'] }}</a>
+      </td>
+      <td>
+        <a class="acct-link" href="{{ url_for('filtered_transactions', account_name=trans['dest']) }}">{{ trans['dest'] }}</a>
+      </td>
 	<td>{{ trans['date'] }}</td>
 	<td>{{ trans['description'] }}</td>
 	<td>{{ trans['amount'] }}</td>

--- a/run.sh
+++ b/run.sh
@@ -16,7 +16,7 @@ fi
 touch $GCH_LOG_DIR/gnucash-helper.log
 export GNUCASH_DIR=$GCH_DEV
 export GNUCASH_FILE=demo-budget.gnucash
-export NUM_TRANSACTIONS=200
+export NUM_TRANSACTIONS=10000
 echo -e "Running gnucash-helper via pipenv run gunicorn...\n"
 pipenv run gunicorn -b 0.0.0.0:8000 --worker-tmp-dir /dev/shm gch:app
 


### PR DESCRIPTION
This PR adds the ability to filter the transaction history based on account name. It does this by adding hyperlinks to each account's name on the Balances page and the Transaction History page. All account names are now clickable and will redirect to a URL in the form of `/transactions/<account_name>`, showing all transactions where that account name is either the debit or credit account. Finally!