### PR TITLE
Replace most instances of "gnucash-helper" with "GnuCash-Helper"

### DIFF
--- a/app/templates/404.html
+++ b/app/templates/404.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %} gnucash-helper - Not Found {% endblock %}
+{% block title %} Not Found {% endblock %}
 
 {% block page_content %}
 <div class="page-header">

--- a/app/templates/500.html
+++ b/app/templates/500.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %} gnucash-helper - Internal Server Error {% endblock %}
+{% block title %} Internal Server Error {% endblock %}
 
 {% block page_content %}
 <div class="page-header">

--- a/app/templates/accounts.html
+++ b/app/templates/accounts.html
@@ -2,7 +2,7 @@
 
 {% import "bootstrap/wtf.html" as wtf %}
 
-{% block title %} gnucash-helper  {% endblock %}
+{% block title %} Manage Accounts {% endblock %}
 {% block styles %}
 {{ super() }}
 <link rel="stylesheet" href="{{ url_for('static', filename='accounts.css')  }}">

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -4,7 +4,7 @@
 <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon-32.png') }}">
 <link rel="apple-touch-icon" href="{{ url_for('static', filename='gnucash-helper-bubble-logo_08-180x180.png') }}">
 {% endblock %}
-{% block title %}gnucash-helper{% endblock %}
+{% block title %}GnuCash-Helper{% endblock %}
 {% block navbar %}
 <div class="navbar navbar-inverse" role="navigation">
   <div class="container">

--- a/app/templates/delete_txn.html
+++ b/app/templates/delete_txn.html
@@ -2,7 +2,7 @@
 
 {% import "bootstrap/wtf.html" as wtf %}
 
-{% block title %} gnucash-helper  {% endblock %}
+{% block title %} Delete a Transaction {% endblock %}
 {% block styles %}
 {{ super() }}
 <link rel="stylesheet" href="{{ url_for('static', filename='delete_txn.css')  }}">

--- a/app/templates/entry.html
+++ b/app/templates/entry.html
@@ -3,7 +3,7 @@
 {% import "bootstrap/wtf.html" as wtf %}
 
 
-{% block title %} gnucash-helper  {% endblock %}
+{% block title %} Enter a Transaction {% endblock %}
 {% block styles %}
 {{ super() }}
 <link rel="stylesheet" href="{{ url_for('static', filename='entry.css')  }}">

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -2,10 +2,10 @@
 
 {% import "bootstrap/wtf.html" as wtf %}
 
-{% block title %} gnucash-helper  {% endblock %}
+{% block title %} GnuCash-Helper {% endblock %}
 {% block page_content %}
 <div class="page-header">
-  <h1>Welcome to gnucash-helper!</h1>
+  <h1>Welcome to GnuCash-Helper!</h1>
 </div>
 <div class="logo">
   <img src="{{ url_for('static', filename='gnucash-helper-bubble-logo_08-300x300.png') }}">


### PR DESCRIPTION
To keep branding consistent, replace lowercase `gnucash-helper` with `GnuCash-Helper` nearly everywhere. The `README.md` file still has it wrong, but I will fix that in a subsequent PR when I overhaul that file.