### PR TITLE
Add 4 Features

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-20220801
+FROM debian:bullseye-20221114
 
 LABEL "maintainer"="brendenahyde@gmail.com"
 
@@ -15,12 +15,7 @@ ADD requirements.txt requirements.txt
 RUN /usr/bin/pip3 install -r requirements.txt
 COPY app/ app/
 ADD gch.py gch.py
-ADD flask_db_init.sh flask_db_init.sh
 ADD config.py config.py
-
-# Configure the local sqlite3 DB to hold users.
-# This file deletes itself after configuring the DB.
-RUN ./flask_db_init.sh
 
 EXPOSE 8000
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,6 +8,8 @@ from flask_sqlalchemy import SQLAlchemy
 
 from config import Config
 
+GCH_VERSION = "0.7.9"
+
 app = Flask(__name__)
 app.config.from_object(Config)
 db = SQLAlchemy(app)

--- a/app/forms.py
+++ b/app/forms.py
@@ -161,11 +161,12 @@ class DeleteEasyButton(FlaskForm):
         global logger
         logger.info('Attempting to read GnuCash book to create DeleteEasyButton form.')
         buttons = get_easy_button_values()
+        summaries = []
 
         # List of summarized txns to display in dropdown box
-        summaries = []
-        for b in buttons.keys():
-            summaries.append(f'{b}  ({buttons[b]["emoji"]})')
+        if buttons is not None:
+            for b in buttons.keys():
+                summaries.append(f'{b}  ({buttons[b]["emoji"]})')
 
         del_easy_form = cls()
         del_easy_form.delete.choices = summaries

--- a/app/gnucash_helper.py
+++ b/app/gnucash_helper.py
@@ -53,7 +53,7 @@ def validate_easy_button_schema(btns):
     schema = Schema({Required(All(str, Length(min=1))): {Required('source'): All(str, Length(min=1)),
                      Required('dest'): All(str, Length(min=1)),
                      Required('descrip'): All(str, Length(min=1)),
-                     Required('emoji'): All(str, Length(min=1, max=2))}})
+                     Required('emoji'): All(str, Length(min=1))}})
 
     # Validate each button definition individually from easy-buttons.yml
     for k, v in btns.items():

--- a/app/gnucash_helper.py
+++ b/app/gnucash_helper.py
@@ -76,6 +76,8 @@ def get_easy_button_values():
 
             if validate_easy_button_schema(btns):
                 return btns
+            else:
+                logger.error("Schema validation failed for easy-buttons.yml")
 
     except FileNotFoundError:
         err = 'Failed to find easy button config. file. '

--- a/app/routes.py
+++ b/app/routes.py
@@ -6,7 +6,7 @@ from flask import render_template, redirect, url_for, flash, request, send_from_
 from flask_login import login_required, login_user, logout_user, current_user
 from werkzeug.urls import url_parse
 
-from app import app, db
+from app import app, db, GCH_VERSION
 from app.forms import AddAccountForm, AddEasyButton, DeleteTransactionForm,\
     DeleteAccountForm, DeleteEasyButton, TransactionForm, RegistrationForm,\
     LoginForm, ExportForm
@@ -26,9 +26,10 @@ book_exists = os.path.exists(path_to_book)
 @app.route('/')
 def index():
     global logger
+    global GCH_VERSION
     logger.debug('Rendering the index page')
 
-    return render_template('index.html')
+    return render_template('index.html', gch_version=GCH_VERSION)
 
 
 @app.route('/entry', methods=['GET', 'POST'])
@@ -154,7 +155,7 @@ def transactions():
 
     return render_template('transactions.html',
                            transactions=transactions,
-                           n=num_transactions)
+                           n=len(transactions))
 
 
 @app.route('/transactions/<account_name>')

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -6,6 +6,7 @@
 {% block page_content %}
 <div class="page-header">
   <h1>Welcome to GnuCash-Helper!</h1>
+    <h2>Version {{ gch_version }}</h2>
 </div>
 <div class="logo">
   <img src="{{ url_for('static', filename='gnucash-helper-bubble-logo_08-300x300.png') }}">

--- a/app/templates/transactions.html
+++ b/app/templates/transactions.html
@@ -8,7 +8,7 @@
 {% block page_content %}
 <div class="page-header">
   <h1>Transaction History</h1>
-  <h3>Last {{ n }} transactions</h3>
+  <h3>{{ n }} transactions</h3>
 </div>
 <div>
   <table class="table">

--- a/example-files/demo-budget.gnucash
+++ b/example-files/demo-budget.gnucash
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f497289af9944c6bd6a1e89dec3e1debd6fa041235ebec8030cccaee9d10c2d1
+oid sha256:e4915d89864aa3d0e9aee103c2131daff500d1e419fafa012187a90f1890fd30
 size 225280

--- a/run.sh
+++ b/run.sh
@@ -3,7 +3,7 @@ export FLASK_APP=gch.py
 export GCH_DEV='/home/brenden/gch-dev'
 export GCH_LOG_DIR='/home/brenden/gch-dev/logs'
 export EASY_CONFIG_DIR=$GCH_DEV
-pyenv global 3.9.12
+pyenv global 3.9.14
 cd ~/git/gnucash-helper
 python3 -m pip install --upgrade pipenv
 echo -e "Running pipenv install with no args...\n"


### PR DESCRIPTION
This PR adds 4 features from the backlog:

1. Move the sqlite3 DB outside of the Docker container so it's not ephemeral. Now, when you redeploy GnuCash-Helper, you won't have to re-register!
2. Show the GnuCash-Helper version in the index page.
3. Show the exact number of transactions on the `/transactions` page instead of the maximum allowed number.
4. Handle the situation where the `easy-buttons.yml` file is empty. The file is empty on a new deployment, so you used to have to bootstrap the app by manually adding an `easy-buttons.yml` file to `$GNUCASH_DIR`. Now, you don't even have to be cognizant that the file exists at all.